### PR TITLE
Fix clusterID based filtering in ListK8sNamespace

### DIFF
--- a/pkg/polaris/graphql/k8s/k8s.go
+++ b/pkg/polaris/graphql/k8s/k8s.go
@@ -302,13 +302,13 @@ func (a API) ListK8sNamespace(ctx context.Context, clusterID uuid.UUID) ([]K8sNa
 			ctx,
 			getNamespacesQuery,
 			struct {
-				After     string    `json:"after,omitempty"`
-				Filter    []Filter  `json:"filter,omitempty"`
-				ClusterID uuid.UUID `json:"clusterID"`
+				After        string    `json:"after,omitempty"`
+				Filter       []Filter  `json:"filter,omitempty"`
+				K8sClusterId uuid.UUID `json:"k8sClusterId"`
 			}{
-				After:     cursor,
-				Filter:    []Filter{},
-				ClusterID: clusterID,
+				After:        cursor,
+				Filter:       []Filter{},
+				K8sClusterId: clusterID,
 			},
 		)
 		if err != nil {
@@ -582,12 +582,12 @@ func (a API) GetK8sNamespace(
 		ctx,
 		k8sNamespaceQuery,
 		struct {
-			After   string                     `json:"after,omitempty"`
-			Filters PolarisSnapshotFilterInput `json:"filters,omitempty"`
-			Fid     uuid.UUID                  `json:"fid,omitempty"`
+			After  string                     `json:"after,omitempty"`
+			Filter PolarisSnapshotFilterInput `json:"filter,omitempty"`
+			Fid    uuid.UUID                  `json:"fid,omitempty"`
 		}{
 			After: cursor,
-			Filters: PolarisSnapshotFilterInput{
+			Filter: PolarisSnapshotFilterInput{
 				TimeRange: TimeRangeInput{Start: startTime, End: endTime},
 			},
 			Fid: snappableId,

--- a/pkg/polaris/polaris_test.go
+++ b/pkg/polaris/polaris_test.go
@@ -1132,6 +1132,14 @@ func TestListK8sNamespace(t *testing.T) {
 	}
 	for _, ns := range nss {
 		fmt.Printf("%v\n", ns)
+		// all returned values should match the filter
+		if ns.K8sClusterID != testClusterID {
+			t.Fatalf(
+				"failed to filter based on clusterID: found clusterID %s, but expected %s",
+				ns.K8sClusterID,
+				testClusterID,
+			)
+		}
 	}
 
 }


### PR DESCRIPTION
In ListK8sNamespace,  the clusterID filter was not working as expected
because the json annotation was incorrect. Due to this, namespaces across all clusters
added to the polaris account were being returned, which is unnecessary

Updated the json annotation to the expected value and modified the UT to check
the clusterID in the response 
In addition to this, updated another json annotation which also had a mismatch

Verified that the UT works with the fixed code