### PR TITLE
Update graphql queries to use the new names

### DIFF
--- a/pkg/polaris/graphql/k8s/k8s.go
+++ b/pkg/polaris/graphql/k8s/k8s.go
@@ -261,7 +261,7 @@ func (a API) ListSLA(ctx context.Context) ([]core.GlobalSLA, error) {
 			return nil, err
 		}
 
-		a.GQL.Log().Printf(log.Debug, "globalSlaConnection(): %s", string(buf))
+		a.GQL.Log().Printf(log.Debug, "slaDomains(): %s", string(buf))
 
 		var payload struct {
 			Data struct {
@@ -274,7 +274,7 @@ func (a API) ListSLA(ctx context.Context) ([]core.GlobalSLA, error) {
 						EndCursor   string `json:"endCursor"`
 						HasNextPage bool   `json:"hasNextPage"`
 					} `json:"pageInfo"`
-				} `json:"globalSlaConnection"`
+				} `json:"slaDomains"`
 			} `json:"data"`
 		}
 		if err := json.Unmarshal(buf, &payload); err != nil {
@@ -368,7 +368,7 @@ func (a API) GetTaskchainInfo(
 	)
 	var payload struct {
 		Data struct {
-			Info TaskchainInfo `json:"getTaskchainInfo"`
+			Info TaskchainInfo `json:"taskchainInfo"`
 		} `json:"data"`
 	}
 
@@ -596,6 +596,7 @@ func (a API) GetK8sNamespace(
 	if err != nil {
 		return nil, "", err
 	}
+	a.GQL.Log().Printf(log.Debug, "GetK8sNamespace(%s): %s", snappableId.String(), string(buf))
 
 	var payload struct {
 		Data struct {

--- a/pkg/polaris/graphql/k8s/queries.go
+++ b/pkg/polaris/graphql/k8s/queries.go
@@ -142,7 +142,7 @@ var getTaskchainInfoQuery = `query SdkGolangGetTaskchainInfo(
     $taskchainId: String!,
     $jobType: String!,
 ) {
-    getTaskchainInfo(
+    taskchainInfo(
         taskchainId: $taskchainId,
         jobType: $jobType,
     ) {
@@ -218,7 +218,7 @@ var k8sNamespaceQuery = `query SdkGolangK8sNamespace(
 var listSlaQuery = `query SdkGolangListSla(
     $after: String,
     $filter: [GlobalSlaFilterInput!]) {
-    globalSlaConnection(
+    slaDomains(
         after: $after,
         filter: $filter,
     ) {
@@ -226,7 +226,7 @@ var listSlaQuery = `query SdkGolangListSla(
             node {
                 id,
                 name,
-                ... on GlobalSla {
+                ... on GlobalSlaReply {
                     baseFrequency {
                         duration,
                         unit,

--- a/pkg/polaris/graphql/k8s/queries/get_taskchain_info.graphql
+++ b/pkg/polaris/graphql/k8s/queries/get_taskchain_info.graphql
@@ -2,7 +2,7 @@ query RubrikPolarisSDKRequest(
     $taskchainId: String!,
     $jobType: String!,
 ) {
-    getTaskchainInfo(
+    taskchainInfo(
         taskchainId: $taskchainId,
         jobType: $jobType,
     ) {

--- a/pkg/polaris/graphql/k8s/queries/list_sla.graphql
+++ b/pkg/polaris/graphql/k8s/queries/list_sla.graphql
@@ -1,7 +1,7 @@
 query RubrikPolarisSDKRequest(
     $after: String,
     $filter: [GlobalSlaFilterInput!]) {
-    globalSlaConnection(
+    slaDomains(
         after: $after,
         filter: $filter,
     ) {
@@ -9,7 +9,7 @@ query RubrikPolarisSDKRequest(
             node {
                 id,
                 name,
-                ... on GlobalSla {
+                ... on GlobalSlaReply {
                     baseFrequency {
                         duration,
                         unit,


### PR DESCRIPTION
Update the graphql query name and return type to match polaris APIs

Verified the updated endpoint call using the UT