### PR TITLE
Fix code violations and add E2E integration

### DIFF
--- a/pkg/polaris/graphql/infinity-k8s/export_test.go
+++ b/pkg/polaris/graphql/infinity-k8s/export_test.go
@@ -1,0 +1,11 @@
+package infinityk8s
+
+import "context"
+
+// GetResourceSetSnapshots exports the private function for testing purposes.
+func (a API) GetResourceSetSnapshots(ctx context.Context, fid string) (
+	[]string,
+	error,
+) {
+	return a.getResourceSetSnapshots(ctx, fid)
+}

--- a/pkg/polaris/graphql/infinity-k8s/infinity_k8s.go
+++ b/pkg/polaris/graphql/infinity-k8s/infinity_k8s.go
@@ -20,8 +20,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-// Package infinityk8s provides a low level interface to the Infinity K8s GraphQL queries
-// provided by the Polaris platform.
+// Package infinityk8s provides a low level interface to the Infinity K8s
+// GraphQL queries provided by the Polaris platform.
 package infinityk8s
 
 import (
@@ -37,45 +37,51 @@ import (
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
 )
 
+// JobInstanceDetail describes the state of a CDM job.
 type JobInstanceDetail struct {
 	Status             string  `json:"status"`
 	StartTime          string  `json:"startTime,omitempty"`
 	Result             string  `json:"result,omitempty"`
 	OpentracingContext string  `json:"opentracingContext,omitempty"`
-	NodeId             string  `json:"nodeId"`
+	NodeID             string  `json:"nodeId"`
 	JobType            string  `json:"jobType"`
 	JobProgress        float64 `json:"jobProgress,omitempty"`
 	IsDisabled         bool    `json:"isDisabled"`
-	Id                 string  `json:"id"`
+	ID                 string  `json:"id"`
 	ErrorInfo          string  `json:"errorInfo,omitempty"`
 	EndTime            string  `json:"endTime,omitempty"`
 	ChildJobDebugInfo  string  `json:"childJobDebugInfo,omitempty"`
 	Archived           bool    `json:"archived"`
 }
 
+// AddK8sResourceSetConfig defines the input parameters required to a
+// ResourceSet.
 type AddK8sResourceSetConfig struct {
 	Definition            string   `json:"definition"`
 	HookConfigs           []string `json:"hookConfigs,omitempty"`
-	K8sClusterUuid        string   `json:"k8SClusterUuid,omitempty"`
+	K8sClusterUUID        string   `json:"k8SClusterUuid,omitempty"`
 	K8sNamespace          string   `json:"k8SNamespace,omitempty"`
-	KubernetesClusterUuid string   `json:"kubernetesClusterUuid,omitempty"`
+	KubernetesClusterUUID string   `json:"kubernetesClusterUuid,omitempty"`
 	KubernetesNamespace   string   `json:"kubernetesNamespace,omitempty"`
 	Name                  string   `json:"name"`
 	RSType                string   `json:"rsType"`
 }
 
+// AddK8sResourceSetResponse is the response received from adding a K8s cluster.
 type AddK8sResourceSetResponse struct {
-	Id                    string   `json:"id"`
+	ID                    string   `json:"id"`
 	Definition            string   `json:"definition"`
 	HookConfigs           []string `json:"hookConfigs,omitempty"`
-	K8sClusterUuid        string   `json:"k8SClusterUuid,omitempty"`
+	K8sClusterUUID        string   `json:"k8SClusterUuid,omitempty"`
 	K8sNamespace          string   `json:"k8SNamespace,omitempty"`
-	KubernetesClusterUuid string   `json:"kubernetesClusterUuid,omitempty"`
+	KubernetesClusterUUID string   `json:"kubernetesClusterUuid,omitempty"`
 	KubernetesNamespace   string   `json:"kubernetesNamespace,omitempty"`
 	Name                  string   `json:"name"`
 	RSType                string   `json:"rsType"`
 }
 
+// ExportK8sResourceSetSnapshotJobConfig defines parameters required to
+// export a snapshot.
 type ExportK8sResourceSetSnapshotJobConfig struct {
 	TargetNamespaceName string `json:"targetNamespaceName"`
 	TargetClusterFid    string `json:"targetClusterId"`
@@ -83,30 +89,36 @@ type ExportK8sResourceSetSnapshotJobConfig struct {
 	Filter              string `json:"filter,omitempty"`
 }
 
+// BaseOnDemandSnapshotConfigInput defines parameters required to take an
+// on-demand snapshot.
 type BaseOnDemandSnapshotConfigInput struct {
 	SLAID string `json:"slaId"`
 }
 
+// Link has the REST link to the job.
 type Link struct {
 	Rel  string `json:"rel"`
 	Href string `json:"href"`
 }
 
+// RequestErrorInfo contains request error message if any.
 type RequestErrorInfo struct {
 	Message string `json:"message"`
 }
 
+// AsyncRequestStatus is the status of the submitted jobs.
 type AsyncRequestStatus struct {
 	Status    string           `json:"status"`
 	StartTime time.Time        `json:"startTime,omitempty"`
 	Progress  float64          `json:"progress,omitempty"`
-	NodeId    string           `json:"nodeId,omitempty"`
+	NodeID    string           `json:"nodeId,omitempty"`
 	Links     []Link           `json:"links"`
-	Id        string           `json:"id"`
+	ID        string           `json:"id"`
 	Error     RequestErrorInfo `json:"error,omitempty"`
 	EndTime   time.Time        `json:"endTime,omitempty"`
 }
 
+// PathNode is the path description of the Snappable.
 type PathNode struct {
 	Fid  uuid.UUID `json:"fid"`
 	Name string    `json:"name"`
@@ -114,10 +126,11 @@ type PathNode struct {
 	ObjectType string `json:"objectType"`
 }
 
+// DataLocation defines the primary location of a Snappable.
 type DataLocation struct {
-	ClusterUuid uuid.UUID `json:"clusterUuid"`
+	ClusterUUID uuid.UUID `json:"clusterUuid"`
 	CreateDate  string    `json:"createDate"`
-	Id          string    `json:"id"`
+	ID          string    `json:"id"`
 	IsActive    bool      `json:"isActive"`
 	IsArchived  bool      `json:"isArchived"`
 	Name        string    `json:"name"`
@@ -125,28 +138,35 @@ type DataLocation struct {
 	Type string `json:"type"`
 }
 
+// KubernetesResourceSet contains fields contained in a ResourceSet snappable.
 type KubernetesResourceSet struct {
-	CdmId                       string         `json:"cdmId"`
-	ClusterUuid                 string         `json:"clusterUuid"`
-	ConfiguredSlaDomain         core.SLADomain `json:"configuredSlaDomain"`
-	EffectiveRetentionSlaDomain core.SLADomain `json:"effectiveRetentionSlaDomain,omitempty"`
-	EffectiveSlaDomain          core.SLADomain `json:"effectiveSlaDomain"`
-	EffectiveSlaSourceObject    PathNode       `json:"effectiveSlaSourceObject"`
-	Id                          uuid.UUID      `json:"id"`
+	CDMID                       string         `json:"cdmId"`
+	ClusterUUID                 string         `json:"clusterUuid"`
+	ConfiguredSLADomain         core.SLADomain `json:"configuredSlaDomain"`
+	EffectiveRetentionSLADomain core.SLADomain `json:"effectiveRetentionSlaDomain,omitempty"`
+	EffectiveSLADomain          core.SLADomain `json:"effectiveSlaDomain"`
+	EffectiveSLASourceObject    PathNode       `json:"effectiveSlaSourceObject"`
+	ID                          uuid.UUID      `json:"id"`
 	IsRelic                     bool           `json:"isRelic"`
-	K8sClusterUuid              uuid.UUID      `json:"k8sClusterUuid"`
+	K8sClusterUUID              uuid.UUID      `json:"k8sClusterUuid"`
 	Name                        string         `json:"Name"`
 	Namespace                   string         `json:"namespace,omitempty"`
 	// ObjectType corresponds to HierarchyObjectTypeEnum.
 	ObjectType             string             `json:"objectType"`
-	PendingSla             core.SLADomain     `json:"pendingSla,omitempty"`
+	PendingSLA             core.SLADomain     `json:"pendingSla,omitempty"`
 	PrimaryClusterLocation DataLocation       `json:"primaryClusterLocation"`
-	PrimaryClusterUuid     uuid.UUID          `json:"primaryClusterUuid"`
+	PrimaryClusterUUID     uuid.UUID          `json:"primaryClusterUuid"`
 	ReplicatedObjectCount  int                `json:"replicatedObjectCount"`
-	RsName                 string             `json:"rsName"`
-	RsType                 string             `json:"rsType"`
-	SlaAssignment          core.SLAAssignment `json:"slaAssignment"`
-	SlaPauseStatus         bool               `json:"slaPauseStatus"`
+	RSName                 string             `json:"rsName"`
+	RSType                 string             `json:"rsType"`
+	SLAAssignment          core.SLAAssignment `json:"slaAssignment"`
+	SLAPauseStatus         bool               `json:"slaPauseStatus"`
+}
+
+// BaseSnapshotSummary picks ID and SLAID fields from the GetSnapshot response.
+type BaseSnapshotSummary struct {
+	ID    string `json:"id"`
+	SLAID string `json:"slaId"`
 }
 
 // API wraps around GraphQL clients to give them the RSC Infinity K8s API.
@@ -167,11 +187,16 @@ func (a API) AddK8sResourceSet(
 ) (AddK8sResourceSetResponse, error) {
 	a.log.Print(log.Trace)
 
-	buf, err := a.GQL.Request(ctx, addK8sResourcesetQuery, struct {
-		Config AddK8sResourceSetConfig `json:"config"`
-	}{Config: config})
+	buf, err := a.GQL.Request(
+		ctx, addK8sResourcesetQuery, struct {
+			Config AddK8sResourceSetConfig `json:"config"`
+		}{Config: config},
+	)
 	if err != nil {
-		return AddK8sResourceSetResponse{}, fmt.Errorf("failed to request addK8sResourceSet: %w", err)
+		return AddK8sResourceSetResponse{}, fmt.Errorf(
+			"failed to request addK8sResourceSet: %w",
+			err,
+		)
 	}
 	a.log.Printf(log.Debug, "addK8sResourceSet(%v): %s", config, string(buf))
 
@@ -181,7 +206,10 @@ func (a API) AddK8sResourceSet(
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(buf, &payload); err != nil {
-		return AddK8sResourceSetResponse{}, fmt.Errorf("failed to unmarshal addK8sResourceSet: %v", err)
+		return AddK8sResourceSetResponse{}, fmt.Errorf(
+			"failed to unmarshal addK8sResourceSet: %v",
+			err,
+		)
 	}
 
 	return payload.Data.Config, nil
@@ -194,11 +222,16 @@ func (a API) GetK8sResourceSet(
 ) (KubernetesResourceSet, error) {
 	a.log.Print(log.Trace)
 
-	buf, err := a.GQL.Request(ctx, k8sResourcesetQuery, struct {
-		Fid uuid.UUID `json:"fid"`
-	}{Fid: fid})
+	buf, err := a.GQL.Request(
+		ctx, k8sResourcesetQuery, struct {
+			Fid uuid.UUID `json:"fid"`
+		}{Fid: fid},
+	)
 	if err != nil {
-		return KubernetesResourceSet{}, fmt.Errorf("failed to request kubernetesResourceSet: %w", err)
+		return KubernetesResourceSet{}, fmt.Errorf(
+			"failed to request kubernetesResourceSet: %w",
+			err,
+		)
 	}
 	a.log.Printf(log.Debug, "kubernetesResourceSet(%v): %s", fid, string(buf))
 
@@ -208,13 +241,17 @@ func (a API) GetK8sResourceSet(
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(buf, &payload); err != nil {
-		return KubernetesResourceSet{}, fmt.Errorf("failed to unmarshal kubernetesResourceSet: %v", err)
+		return KubernetesResourceSet{}, fmt.Errorf(
+			"failed to unmarshal kubernetesResourceSet: %v",
+			err,
+		)
 	}
 
 	return payload.Data.KubernetesResourceSet, nil
 }
 
-// DeleteK8sResourceSet deletes the K8s resource set corresponding to the provided fid.
+// DeleteK8sResourceSet deletes the K8s resource set corresponding to the
+// provided fid.
 func (a API) DeleteK8sResourceSet(
 	ctx context.Context,
 	fid string,
@@ -226,10 +263,10 @@ func (a API) DeleteK8sResourceSet(
 		ctx,
 		deleteK8sResourcesetQuery,
 		struct {
-			Id                string `json:"id"`
+			ID                string `json:"id"`
 			PreserveSnapshots bool   `json:"preserveSnapshots"`
 		}{
-			Id:                fid,
+			ID:                fid,
 			PreserveSnapshots: preserveSnapshots,
 		},
 	)
@@ -237,7 +274,13 @@ func (a API) DeleteK8sResourceSet(
 	if err != nil {
 		return false, fmt.Errorf("failed to request deleteK8sResourceset: %w", err)
 	}
-	a.log.Printf(log.Debug, "deleteK8sResourceset(%q, %q): %s", fid, preserveSnapshots, string(buf))
+	a.log.Printf(
+		log.Debug,
+		"deleteK8sResourceset(%q, %q): %s",
+		fid,
+		preserveSnapshots,
+		string(buf),
+	)
 
 	var payload struct {
 		Data struct {
@@ -248,21 +291,27 @@ func (a API) DeleteK8sResourceSet(
 	}
 
 	if err := json.Unmarshal(buf, &payload); err != nil {
-		return false, fmt.Errorf("failed to unmarshal deleteK8sResourceset response: %v", err)
+		return false, fmt.Errorf(
+			"failed to unmarshal deleteK8sResourceset response: %v",
+			err,
+		)
 	}
 	if !payload.Data.ResponseSuccess.Success {
-		return false, fmt.Errorf("failed to delete k8s resource set with fid %q", fid)
+		return false, fmt.Errorf(
+			"failed to delete k8s resource set with fid %q",
+			fid,
+		)
 	}
 
 	return true, nil
 }
 
-// GetJobInstance fetches information about the CDM job corresponding to the given
-// jobId and cdmClusterId
+// GetJobInstance fetches information about the CDM job corresponding to the
+// given jobID and cdmClusterID.
 func (a API) GetJobInstance(
 	ctx context.Context,
-	jobId string,
-	cdmClusterId string,
+	jobID string,
+	cdmClusterID string,
 ) (JobInstanceDetail, error) {
 	a.log.Print(log.Trace)
 
@@ -270,18 +319,27 @@ func (a API) GetJobInstance(
 		ctx,
 		jobInstanceQuery,
 		struct {
-			JobId        string `json:"id"`
-			CDMClusterId string `json:"clusterUuid"`
+			JobID        string `json:"id"`
+			CDMClusterID string `json:"clusterUuid"`
 		}{
-			JobId:        jobId,
-			CDMClusterId: cdmClusterId,
+			JobID:        jobID,
+			CDMClusterID: cdmClusterID,
 		},
 	)
 
 	if err != nil {
-		return JobInstanceDetail{}, fmt.Errorf("failed to request jobInstance: %w", err)
+		return JobInstanceDetail{}, fmt.Errorf(
+			"failed to request jobInstance: %w",
+			err,
+		)
 	}
-	a.log.Printf(log.Debug, "jobInstance(%q, %q): %s", jobId, cdmClusterId, string(buf))
+	a.log.Printf(
+		log.Debug,
+		"jobInstance(%q, %q): %s",
+		jobID,
+		cdmClusterID,
+		string(buf),
+	)
 
 	var payload struct {
 		Data struct {
@@ -290,14 +348,17 @@ func (a API) GetJobInstance(
 	}
 
 	if err := json.Unmarshal(buf, &payload); err != nil {
-		return JobInstanceDetail{}, fmt.Errorf("failed to unmarshal jobInstance response: %v", err)
+		return JobInstanceDetail{}, fmt.Errorf(
+			"failed to unmarshal jobInstance response: %v",
+			err,
+		)
 	}
 
 	return payload.Data.Response, nil
 }
 
-// ExportK8sResourceSetSnapshot takes a snapshot FID, the export job config and starts
-// an on-demand export job in CDM.
+// ExportK8sResourceSetSnapshot takes a snapshot FID, the export job config and
+// starts an on-demand export job in CDM.
 func (a API) ExportK8sResourceSetSnapshot(
 	ctx context.Context,
 	snapshotFid string,
@@ -318,9 +379,18 @@ func (a API) ExportK8sResourceSetSnapshot(
 	)
 
 	if err != nil {
-		return AsyncRequestStatus{}, fmt.Errorf("failed to request exportK8sResourceSetSnapshot: %w", err)
+		return AsyncRequestStatus{}, fmt.Errorf(
+			"failed to request exportK8sResourceSetSnapshot: %w",
+			err,
+		)
 	}
-	a.log.Printf(log.Debug, "exportK8sResourceSetSnapshot(%q, %q): %s", snapshotFid, jobConfig, string(buf))
+	a.log.Printf(
+		log.Debug,
+		"exportK8sResourceSetSnapshot(%q, %q): %s",
+		snapshotFid,
+		jobConfig,
+		string(buf),
+	)
 
 	var payload struct {
 		Data struct {
@@ -329,7 +399,10 @@ func (a API) ExportK8sResourceSetSnapshot(
 	}
 
 	if err := json.Unmarshal(buf, &payload); err != nil {
-		return AsyncRequestStatus{}, fmt.Errorf("failed to unmarshal exportK8sResourceSetSnapshot response: %v", err)
+		return AsyncRequestStatus{}, fmt.Errorf(
+			"failed to unmarshal exportK8sResourceSetSnapshot response: %v",
+			err,
+		)
 	}
 
 	return payload.Data.Response, nil
@@ -348,18 +421,27 @@ func (a API) CreateK8sResourceSnapshot(
 		ctx,
 		createK8sResourceSnapshotQuery,
 		struct {
-			ResourceSetId string                          `json:"resourceSetId"`
+			ResourceSetID string                          `json:"resourceSetId"`
 			JobConfig     BaseOnDemandSnapshotConfigInput `json:"jobConfig"`
 		}{
-			ResourceSetId: resourceSetFID,
+			ResourceSetID: resourceSetFID,
 			JobConfig:     jobConfig,
 		},
 	)
 
 	if err != nil {
-		return AsyncRequestStatus{}, fmt.Errorf("failed to request createK8sResourceSetSnapshot: %w", err)
+		return AsyncRequestStatus{}, fmt.Errorf(
+			"failed to request createK8sResourceSetSnapshot: %w",
+			err,
+		)
 	}
-	a.log.Printf(log.Debug, "createK8sResourceSetSnapshot(%q, %q): %s", resourceSetFID, jobConfig, string(buf))
+	a.log.Printf(
+		log.Debug,
+		"createK8sResourceSetSnapshot(%q, %q): %s",
+		resourceSetFID,
+		jobConfig,
+		string(buf),
+	)
 
 	var payload struct {
 		Data struct {
@@ -368,18 +450,21 @@ func (a API) CreateK8sResourceSnapshot(
 	}
 
 	if err := json.Unmarshal(buf, &payload); err != nil {
-		return AsyncRequestStatus{}, fmt.Errorf("failed to unmarshal createK8sResourceSetSnapshot response: %v", err)
+		return AsyncRequestStatus{}, fmt.Errorf(
+			"failed to unmarshal createK8sResourceSetSnapshot response: %v",
+			err,
+		)
 	}
 
 	return payload.Data.Response, nil
 }
 
-// GetK8sObjectFid fetches the RSC Fid for the object corresponding to the
+// GetK8sObjectFid fetches the RSC FID for the object corresponding to the
 // provided internal id and CDM cluster id.
 func (a API) GetK8sObjectFid(
 	ctx context.Context,
-	internalId uuid.UUID,
-	cdmClusterId uuid.UUID,
+	internalID uuid.UUID,
+	cdmClusterID uuid.UUID,
 ) (uuid.UUID, error) {
 	a.log.Print(log.Trace)
 
@@ -387,33 +472,39 @@ func (a API) GetK8sObjectFid(
 		ctx,
 		k8sObjectFidQuery,
 		struct {
-			InternalId  uuid.UUID `json:"k8SObjectInternalIdArg"`
-			ClusterUuid uuid.UUID `json:"clusterUuid"`
+			InternalID  uuid.UUID `json:"k8SObjectInternalIdArg"`
+			ClusterUUID uuid.UUID `json:"clusterUuid"`
 		}{
-			InternalId:  internalId,
-			ClusterUuid: cdmClusterId,
+			InternalID:  internalID,
+			ClusterUUID: cdmClusterID,
 		},
 	)
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("failed to request k8sObjectFid: %w", err)
 	}
-	a.log.Printf(log.Debug, "k8sObjectFid(%v, %v): %s", internalId, cdmClusterId, string(buf))
+	a.log.Printf(
+		log.Debug,
+		"k8sObjectFid(%v, %v): %s",
+		internalID,
+		cdmClusterID,
+		string(buf),
+	)
 
 	var payload struct {
 		Data struct {
-			ObjectFid uuid.UUID `json:"k8sObjectFid"`
+			ObjectFID uuid.UUID `json:"k8sObjectFid"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(buf, &payload); err != nil {
 		return uuid.Nil, fmt.Errorf("failed to unmarshal k8sObjectFid: %v", err)
 	}
 
-	return payload.Data.ObjectFid, nil
+	return payload.Data.ObjectFID, nil
 }
 
-// GetK8sObjectInternalId fetches the object Internal ID on CDM for the
-// given RSC Fid.
-func (a API) GetK8sObjectInternalId(
+// GetK8sObjectInternalID fetches the object Internal ID on CDM for the
+// given RSC FID.
+func (a API) GetK8sObjectInternalID(
 	ctx context.Context,
 	fid uuid.UUID,
 ) (uuid.UUID, error) {
@@ -423,24 +514,77 @@ func (a API) GetK8sObjectInternalId(
 		ctx,
 		k8sObjectInternalIdQuery,
 		struct {
-			Fid uuid.UUID `json:"fid"`
+			FID uuid.UUID `json:"fid"`
 		}{
-			Fid: fid,
+			FID: fid,
 		},
 	)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("failed to request k8sObjectInternalId: %w", err)
+		return uuid.Nil, fmt.Errorf(
+			"failed to request k8sObjectInternalId: %w",
+			err,
+		)
 	}
 	a.log.Printf(log.Debug, "k8sObjectInternalId(%v): %s", fid, string(buf))
 
 	var payload struct {
 		Data struct {
-			ObjectInternalId uuid.UUID `json:"k8sObjectInternalId"`
+			ObjectInternalID uuid.UUID `json:"k8sObjectInternalId"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(buf, &payload); err != nil {
-		return uuid.Nil, fmt.Errorf("failed to unmarshal k8sObjectInternalId: %v", err)
+		return uuid.Nil, fmt.Errorf(
+			"failed to unmarshal k8sObjectInternalId: %v",
+			err,
+		)
 	}
 
-	return payload.Data.ObjectInternalId, nil
+	return payload.Data.ObjectInternalID, nil
+}
+
+// getResourceSetSnapshots get initial snapshots for a given fid. Only used
+// internally for testing puporses.
+func (a API) getResourceSetSnapshots(
+	ctx context.Context,
+	fid string,
+) ([]string, error) {
+	a.log.Print(log.Trace)
+
+	buf, err := a.GQL.Request(
+		ctx,
+		getResourcesetSnapshotQuery,
+		struct {
+			FID string `json:"fid"`
+		}{
+			FID: fid,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to request k8sObjectInternalId: %w",
+			err,
+		)
+	}
+	a.log.Printf(log.Debug, "k8sResourceSetSnapshots(%v): %s", fid, string(buf))
+
+	var payload struct {
+		Data struct {
+			K8sResourceSnapshots struct {
+				Data []struct {
+					BaseSnapshotSummary BaseSnapshotSummary `json:"baseSnapshotSummary"`
+				} `json:"data"`
+			} `json:"k8sResourceSetSnapshots"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		return nil, fmt.Errorf(
+			"failed to unmarshal k8sResourceSetSnapshots: %v",
+			err,
+		)
+	}
+	snaps := make([]string, len(payload.Data.K8sResourceSnapshots.Data))
+	for i, item := range payload.Data.K8sResourceSnapshots.Data {
+		snaps[i] = item.BaseSnapshotSummary.ID
+	}
+	return snaps, nil
 }

--- a/pkg/polaris/graphql/infinity-k8s/queries.go
+++ b/pkg/polaris/graphql/infinity-k8s/queries.go
@@ -84,6 +84,18 @@ var exportK8sResourcesetSnapshotQuery = `mutation SdkGolangExportK8sResourcesetS
   }
 }`
 
+// getResourcesetSnapshot GraphQL query
+var getResourcesetSnapshotQuery = `query SdkGolangK8sResourceSnapshots($fid: String!) {
+    k8sResourceSetSnapshots(input: {id: $fid}) {
+        data {
+            baseSnapshotSummary {
+                id
+                slaId
+            }
+        }
+    }
+}`
+
 // jobInstance GraphQL query
 var jobInstanceQuery = `query SdkGolangJobInstance($id:String!, $clusterUuid: String!) {
   jobInstance(input: {id:$id, clusterUuid: $clusterUuid}) {

--- a/pkg/polaris/graphql/infinity-k8s/queries/get_resourceset_snapshot.graphql
+++ b/pkg/polaris/graphql/infinity-k8s/queries/get_resourceset_snapshot.graphql
@@ -1,0 +1,10 @@
+query SdkGolangK8sResourceSnapshots($fid: String!) {
+    k8sResourceSetSnapshots(input: {id: $fid}) {
+        data {
+            baseSnapshotSummary {
+                id
+                slaId
+            }
+        }
+    }
+}


### PR DESCRIPTION
Violations Before 
```
infinity_k8s.go:40:6: exported type JobInstanceDetail should have comment or be unexported
infinity_k8s.go:45:2: struct field NodeId should be NodeID
infinity_k8s.go:49:2: struct field Id should be ID
infinity_k8s.go:56:6: exported type AddK8sResourceSetConfig should have comment or be unexported
infinity_k8s.go:59:2: struct field K8sClusterUuid should be K8sClusterUUID
infinity_k8s.go:61:2: struct field KubernetesClusterUuid should be KubernetesClusterUUID
infinity_k8s.go:67:6: exported type AddK8sResourceSetResponse should have comment or be unexported
infinity_k8s.go:68:2: struct field Id should be ID
infinity_k8s.go:71:2: struct field K8sClusterUuid should be K8sClusterUUID
infinity_k8s.go:73:2: struct field KubernetesClusterUuid should be KubernetesClusterUUID
infinity_k8s.go:79:6: exported type ExportK8sResourceSetSnapshotJobConfig should have comment or be unexported
infinity_k8s.go:86:6: exported type BaseOnDemandSnapshotConfigInput should have comment or be unexported
infinity_k8s.go:90:6: exported type Link should have comment or be unexported
infinity_k8s.go:95:6: exported type RequestErrorInfo should have comment or be unexported
infinity_k8s.go:99:6: exported type AsyncRequestStatus should have comment or be unexported
infinity_k8s.go:103:2: struct field NodeId should be NodeID
infinity_k8s.go:105:2: struct field Id should be ID
infinity_k8s.go:110:6: exported type PathNode should have comment or be unexported
infinity_k8s.go:117:6: exported type DataLocation should have comment or be unexported
infinity_k8s.go:118:2: struct field ClusterUuid should be ClusterUUID
infinity_k8s.go:120:2: struct field Id should be ID
infinity_k8s.go:128:6: exported type KubernetesResourceSet should have comment or be unexported
infinity_k8s.go:129:2: struct field CdmId should be CdmID
infinity_k8s.go:130:2: struct field ClusterUuid should be ClusterUUID
infinity_k8s.go:131:2: struct field ConfiguredSlaDomain should be ConfiguredSLADomain
infinity_k8s.go:132:2: struct field EffectiveRetentionSlaDomain should be EffectiveRetentionSLADomain
infinity_k8s.go:133:2: struct field EffectiveSlaDomain should be EffectiveSLADomain
infinity_k8s.go:134:2: struct field EffectiveSlaSourceObject should be EffectiveSLASourceObject
infinity_k8s.go:135:2: struct field Id should be ID
infinity_k8s.go:137:2: struct field K8sClusterUuid should be K8sClusterUUID
infinity_k8s.go:142:2: struct field PendingSla should be PendingSLA
infinity_k8s.go:144:2: struct field PrimaryClusterUuid should be PrimaryClusterUUID
infinity_k8s.go:148:2: struct field SlaAssignment should be SLAAssignment
infinity_k8s.go:149:2: struct field SlaPauseStatus should be SLAPauseStatus
infinity_k8s.go:246:4: struct field Id should be ID
infinity_k8s.go:293:2: method parameter jobId should be jobID
infinity_k8s.go:294:2: method parameter cdmClusterId should be cdmClusterID
infinity_k8s.go:302:4: struct field JobId should be JobID
infinity_k8s.go:303:4: struct field CDMClusterId should be CDMClusterID
infinity_k8s.go:404:4: struct field ResourceSetId should be ResourceSetID
infinity_k8s.go:446:2: method parameter internalId should be internalID
infinity_k8s.go:447:2: method parameter cdmClusterId should be cdmClusterID
infinity_k8s.go:455:4: struct field InternalId should be InternalID
infinity_k8s.go:456:4: struct field ClusterUuid should be ClusterUUID
infinity_k8s.go:487:14: method GetK8sObjectInternalId should be GetK8sObjectInternalID
infinity_k8s.go:512:4: struct field ObjectInternalId should be ObjectInternalID
queries.go:112:5: var k8sObjectInternalIdQuery should be k8sObjectInternalIDQuery
```

After
```
queries.go:124:5: var k8sObjectInternalIdQuery should be k8sObjectInternalIDQuery
```