### PR TITLE
Add support for storage mapping to restore and export graphqls

### DIFF
--- a/pkg/polaris/graphql/infinityk8s/infinityk8s.go
+++ b/pkg/polaris/graphql/infinityk8s/infinityk8s.go
@@ -95,22 +95,58 @@ type AddK8sProtectionSetResponse struct {
 	RSType                string   `json:"rsType"`
 }
 
+// PvcStorageClassMappingEntry represents an entry mapping a PVC name to a
+// target storage class.
+type PvcStorageClassMappingEntry struct {
+	PvcName            string `json:"pvcName"`
+	TargetStorageClass string `json:"targetStorageClass"`
+}
+
+// StorageClassMappingEntry represents an entry mapping a source storage class
+// to a target storage class.
+type StorageClassMappingEntry struct {
+	SourceStorageClass string `json:"sourceStorageClass"`
+	TargetStorageClass string `json:"targetStorageClass"`
+}
+
+// PvcStorageClassMappings wraps the list of PVC storage class mappings.
+type PvcStorageClassMappings struct {
+	PvcStorageClassMappingList []PvcStorageClassMappingEntry `json:"pvcStorageClassMappingList,omitempty"`
+}
+
+// StorageClassMappings wraps the list of storage class mappings.
+type StorageClassMappings struct {
+	StorageClassMappingList []StorageClassMappingEntry `json:"storageClassMappingList,omitempty"`
+}
+
+// StorageMapping defines storage class mappings for restore and export
+// operations.
+type StorageMapping struct {
+	// PvcStorageClassMappings maps specific PVC names to target storage classes.
+	// Takes precedence over StorageClassMappings.
+	PvcStorageClassMappings *PvcStorageClassMappings `json:"pvcStorageClassMappings,omitempty"`
+	// StorageClassMappings maps source storage classes to target storage classes.
+	StorageClassMappings *StorageClassMappings `json:"storageClassMappings,omitempty"`
+}
+
 // ExportK8sProtectionSetSnapshotJobConfig defines parameters required to
 // export a snapshot.
 type ExportK8sProtectionSetSnapshotJobConfig struct {
-	TargetNamespaceName string   `json:"targetNamespaceName"`
-	TargetClusterFID    string   `json:"targetClusterId"`
-	IgnoreErrors        bool     `json:"ignoreErrors,omitempty"`
-	Filter              string   `json:"filter,omitempty"`
-	PVCNames            []string `json:"pvcNames,omitempty"`
+	TargetNamespaceName string          `json:"targetNamespaceName"`
+	TargetClusterFID    string          `json:"targetClusterId"`
+	IgnoreErrors        bool            `json:"ignoreErrors,omitempty"`
+	Filter              string          `json:"filter,omitempty"`
+	PVCNames            []string        `json:"pvcNames,omitempty"`
+	StorageMapping      *StorageMapping `json:"storageMapping,omitempty"`
 }
 
 // RestoreK8sProtectionSetSnapshotJobConfig defines parameters required to
 // export a snapshot.
 type RestoreK8sProtectionSetSnapshotJobConfig struct {
-	IgnoreErrors bool     `json:"ignoreErrors,omitempty"`
-	Filter       string   `json:"filter,omitempty"`
-	PVCNames     []string `json:"pvcNames,omitempty"`
+	IgnoreErrors   bool            `json:"ignoreErrors,omitempty"`
+	Filter         string          `json:"filter,omitempty"`
+	PVCNames       []string        `json:"pvcNames,omitempty"`
+	StorageMapping *StorageMapping `json:"storageMapping,omitempty"`
 }
 
 // BaseOnDemandSnapshotConfigInput defines parameters required to take an
@@ -260,8 +296,8 @@ type K8sClusterAddInput struct {
 	IsAutoPsCreationEnabled bool                       `json:"isAutoPsCreationEnabled,omitempty"`
 	OnboardingType          string                     `json:"onboardingType,omitempty"`
 	KuprServerProxyConfig   KuprServerProxyConfigInput `json:"kuprServerProxyConfig,omitempty"`
-	NadNamespace string `json:"nadNamespace,omitempty"`
-	NadName      string `json:"nadName,omitempty"`
+	NadNamespace            string                     `json:"nadNamespace,omitempty"`
+	NadName                 string                     `json:"nadName,omitempty"`
 }
 
 // K8sClusterSummary is the response for the addK8sCluster query.
@@ -291,8 +327,8 @@ type K8sClusterUpdateConfigInput struct {
 	ClientId                string                     `json:"clientId,omitempty"`
 	ClientSecret            string                     `json:"clientSecret,omitempty"`
 	KuprServerProxyConfig   KuprServerProxyConfigInput `json:"kuprServerProxyConfig,omitempty"`
-	NadNamespace string `json:"nadNamespace,omitempty"`
-	NadName      string `json:"nadName,omitempty"`
+	NadNamespace            string                     `json:"nadNamespace,omitempty"`
+	NadName                 string                     `json:"nadName,omitempty"`
 }
 
 type API struct {

--- a/pkg/polaris/graphql/infinityk8s/infinityk8s_test.go
+++ b/pkg/polaris/graphql/infinityk8s/infinityk8s_test.go
@@ -316,6 +316,24 @@ func TestIntegration(t *testing.T) {
 			TargetClusterFID:    k8sFID.String(),
 			IgnoreErrors:        false,
 			Filter:              "{}",
+			StorageMapping: &infinityk8s.StorageMapping{
+				PvcStorageClassMappings: &infinityk8s.PvcStorageClassMappings{
+					PvcStorageClassMappingList: []infinityk8s.PvcStorageClassMappingEntry{
+						{
+							PvcName:            "mongodata-catalog",
+							TargetStorageClass: "vsphere-storage-class",
+						},
+					},
+				},
+				StorageClassMappings: &infinityk8s.StorageClassMappings{
+					StorageClassMappingList: []infinityk8s.StorageClassMappingEntry{
+						{
+							SourceStorageClass: "rook-ceph-block",
+							TargetStorageClass: "rook-cephfs",
+						},
+					},
+				},
+			},
 		},
 	)
 	if err != nil {
@@ -366,6 +384,24 @@ func TestIntegration(t *testing.T) {
 		infinityk8s.RestoreK8sProtectionSetSnapshotJobConfig{
 			IgnoreErrors: false,
 			Filter:       "{}",
+			StorageMapping: &infinityk8s.StorageMapping{
+				PvcStorageClassMappings: &infinityk8s.PvcStorageClassMappings{
+					PvcStorageClassMappingList: []infinityk8s.PvcStorageClassMappingEntry{
+						{
+							PvcName:            "mongodata-catalog",
+							TargetStorageClass: "vsphere-storage-class",
+						},
+					},
+				},
+				StorageClassMappings: &infinityk8s.StorageClassMappings{
+					StorageClassMappingList: []infinityk8s.StorageClassMappingEntry{
+						{
+							SourceStorageClass: "rook-ceph-block",
+							TargetStorageClass: "rook-cephfs",
+						},
+					},
+				},
+			},
 		},
 	)
 	if err != nil {
@@ -615,4 +651,79 @@ func TestMissingK8sProtectionSet(t *testing.T) {
 		t.Errorf("expected not found error, got %v", err)
 		return
 	}
+}
+
+// TestRestoreWithStorageMappingTemp is a one-time test for restore with storage mapping.
+// Replace the snapshotID with your actual snapshot ID.
+func TestRestoreWithStorageMappingTemp(t *testing.T) {
+	ctx := context.Background()
+
+	if !testsetup.BoolEnvSet("TEST_INTEGRATION") {
+		t.Skipf("skipping due to env TEST_INTEGRATION not set")
+	}
+
+	infinityK8sClient := infinityk8s.Wrap(client)
+	logger := infinityK8sClient.GQL.Log()
+	logger.SetLogLevel(log.Debug)
+
+	// TODO: Replace with your actual snapshot ID
+	snapshotID := "0e7a0a1d-a833-56fd-ae5b-2a2b8afa740b"
+
+	logger.Printf(
+		log.Info,
+		"Starting restore with storage mapping for snapshot: %s",
+		snapshotID,
+	)
+
+	// Restore with storage mapping
+	restoreJobResp, err := infinityK8sClient.RestoreK8sProtectionSetSnapshot(
+		ctx,
+		snapshotID,
+		infinityk8s.RestoreK8sProtectionSetSnapshotJobConfig{
+			IgnoreErrors: false,
+			Filter:       "{}",
+			StorageMapping: &infinityk8s.StorageMapping{
+				PvcStorageClassMappings: &infinityk8s.PvcStorageClassMappings{
+					PvcStorageClassMappingList: []infinityk8s.PvcStorageClassMappingEntry{
+						{
+							PvcName:            "mongodata-catalog",
+							TargetStorageClass: "vsphere-storage-class",
+						},
+					},
+				},
+				StorageClassMappings: &infinityk8s.StorageClassMappings{
+					StorageClassMappingList: []infinityk8s.StorageClassMappingEntry{
+						{
+							SourceStorageClass: "rook-ceph-block",
+							TargetStorageClass: "rook-cephfs",
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Errorf("restore job failed: %v", err)
+		return
+	}
+
+	logger.Printf(log.Info, "Restore job response: %+v", restoreJobResp)
+	logger.Printf(log.Info, "Restore job ID: %s", restoreJobResp.ID)
+
+	// Get the job status
+	getJobResp, err := infinityK8sClient.JobInstance(
+		ctx,
+		restoreJobResp.ID,
+		cdmID.String(),
+	)
+	if err != nil {
+		t.Errorf("failed to get job instance: %v", err)
+		return
+	}
+
+	logger.Printf(log.Info, "Job status: %+v", getJobResp)
+	logger.Printf(log.Info, "Job progress: %s", getJobResp.JobProgress)
+	logger.Printf(log.Info, "Job status: %s", getJobResp.Status)
+
+	t.Logf("Restore job started successfully with ID: %s", restoreJobResp.ID)
 }


### PR DESCRIPTION
Add storage mapping input to graphqls

## Summary:
Adding k8s storage mapping to recovery graphql 

## Test Plan:
TestRestoreWithStorageMappingTemp

## JIRA Issues:
CDM-513922
