### PR TITLE
Add helmChartVersion and helmMinCdmVersion to K8sClusterAddInput

### DIFF
--- a/pkg/polaris/graphql/infinityk8s/infinityk8s.go
+++ b/pkg/polaris/graphql/infinityk8s/infinityk8s.go
@@ -298,6 +298,8 @@ type K8sClusterAddInput struct {
 	KuprServerProxyConfig   KuprServerProxyConfigInput `json:"kuprServerProxyConfig,omitempty"`
 	NadNamespace            string                     `json:"nadNamespace,omitempty"`
 	NadName                 string                     `json:"nadName,omitempty"`
+	HelmChartVersion        string                     `json:"helmChartVersion,omitempty"`
+	HelmMinCdmVersion       string                     `json:"helmMinCdmVersion,omitempty"`
 }
 
 // K8sClusterSummary is the response for the addK8sCluster query.


### PR DESCRIPTION
## Summary

Add helmChartVersion + helmMinCdmVersion to the K8sClusterAddInput Go struct so callers can populate them on the addK8sCluster RSC mutation.

## Why

CDM 9.6 added these fields to the K8sClusterAdd swagger model + a hard helm-version-compat check in K8sApiImpl.addK8sCluster that .get()s both fields when onboardingType == "helm". The Polaris GraphQL schema auto-derives K8sClusterAddInput from the same swagger and already exposes the fields server-side. This SDK update closes the client gap so the in-cluster api-handler (sdmain) can populate them on the RSC AddK8sCluster path.

## Changes

`pkg/polaris/graphql/infinityk8s/infinityk8s.go`:

- `K8sClusterAddInput`: add `HelmChartVersion` and `HelmMinCdmVersion` fields (optional, omitempty)

## Test plan

Struct-only addition. Confirmed JSON tag names (`helmChartVersion`, `helmMinCdmVersion`) match the GraphQL field names in api-server's schema-internal.graphql.

## Follow-up

After merge, a companion scaledata/go-vendor PR will bump `modules.txt` to this SHA and mirror the file edit.
