### PR TITLE
Add batching config fields to K8s cluster input structs

### DIFF
--- a/pkg/polaris/graphql/infinityk8s/infinityk8s.go
+++ b/pkg/polaris/graphql/infinityk8s/infinityk8s.go
@@ -300,6 +300,8 @@ type K8sClusterAddInput struct {
 	NadName                 string                     `json:"nadName,omitempty"`
 	HelmChartVersion        string                     `json:"helmChartVersion,omitempty"`
 	HelmMinCdmVersion       string                     `json:"helmMinCdmVersion,omitempty"`
+	MaxPvcsPerAgent         *int32                     `json:"maxPvcsPerAgent,omitempty"`
+	MaxConcurrentAgents     *int32                     `json:"maxConcurrentAgents,omitempty"`
 }
 
 // K8sClusterSummary is the response for the addK8sCluster query.
@@ -331,6 +333,8 @@ type K8sClusterUpdateConfigInput struct {
 	KuprServerProxyConfig   KuprServerProxyConfigInput `json:"kuprServerProxyConfig,omitempty"`
 	NadNamespace            string                     `json:"nadNamespace,omitempty"`
 	NadName                 string                     `json:"nadName,omitempty"`
+	MaxPvcsPerAgent         *int32                     `json:"maxPvcsPerAgent,omitempty"`
+	MaxConcurrentAgents     *int32                     `json:"maxConcurrentAgents,omitempty"`
 }
 
 type API struct {


### PR DESCRIPTION
## Summary

Add `MaxPvcsPerAgent` and `MaxConcurrentAgents` optional fields to
`K8sClusterAddInput` and `K8sClusterUpdateConfigInput` structs.

These fields support the PVC batching feature (CDM-537550), allowing
CDM to pass batching configuration limits through RSC GraphQL APIs
during K8s cluster onboarding and config updates.

Both fields are `*int32` with `omitempty` — fully backward compatible.

## Test Plan

- Existing integration tests pass (fields are optional, no existing
  callers need changes)
- Validated by api-handler unit tests in sdmain that construct these
  structs with the new fields
